### PR TITLE
fix: 1:1アスペクト比のDNGファイルの無駄な回転を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ luac.out
 *.hex
 
 config.yaml
+*.pyc

--- a/DRSorter.py
+++ b/DRSorter.py
@@ -385,10 +385,14 @@ def main():
                                 scale_x = (jpeg_width / dng_width) * (dng_height / jpeg_height)
                                 scale_y = 1.0
                                 scale = max(scale_x, scale_y)
-                            else:  # 縦写真の場合
+                            elif jpeg_width < jpeg_height:  # 縦写真の場合
                                 # 既存のロジックを維持
                                 scale = jpeg_height / jpeg_width
                                 item.SetProperty("RotationAngle", config.get_rotation_angle())
+                            else:  # 正方形（1:1アスペクト比）の場合
+                                # 回転処理なし、スケール調整のみ
+                                # 正方形の場合はDNGをJPEGの解像度に合わせる
+                                scale = dng_width / jpeg_width
                             
                             item.SetProperty("ZoomX", scale)
                             item.SetProperty("ZoomY", scale)  # Y軸にも同じスケールを適用


### PR DESCRIPTION
## 概要
Issue #18 を修正し、1:1アスペクト比（正方形）のDNGファイルが無駄に90度回転される問題を解決しました。

## 変更内容
- 縦横判定ロジックで正方形（1:1アスペクト比）のケースを新たに追加
- 正方形の場合は回転処理を行わず、スケール調整のみを実行
- スケール計算式を適正化（`dng_width / jpeg_width`）

## 修正前の問題
- `jpeg_width <= jpeg_height` の条件により、正方形画像も縦写真として処理
- 1:1アスペクト比のSigma BFのDNGファイルが不要に90度回転

## 修正後の動作
- 横写真（`jpeg_width > jpeg_height`）: 既存処理のまま
- 縦写真（`jpeg_width < jpeg_height`）: 90度回転適用
- 正方形（`jpeg_width == jpeg_height`）: 回転なし、適切なスケール調整

## テスト結果
- 1:1アスペクト比のDNGファイルが正常にスケール調整され、回転されない
- 従来の横写真・縦写真の処理に影響なし

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)