### PR TITLE
Fix: 縦写真の拡大率計算を統一的な計算式に修正

### DIFF
--- a/DRSorter.py
+++ b/DRSorter.py
@@ -386,8 +386,8 @@ def main():
                                 scale_y = 1.0
                                 scale = max(scale_x, scale_y)
                             elif jpeg_width < jpeg_height:  # 縦写真の場合
-                                # 既存のロジックを維持
-                                scale = jpeg_height / jpeg_width
+                                # DNGの幅をJPEGの幅で割る統一計算式
+                                scale = dng_width / jpeg_width
                                 item.SetProperty("RotationAngle", config.get_rotation_angle())
                             else:  # 正方形（1:1アスペクト比）の場合
                                 # 回転処理なし、スケール調整のみ


### PR DESCRIPTION
## 概要
縦写真の拡大率計算を統一的な計算式に修正し、4012x4980で期待値1.5倍が得られるようにしました。

## 問題
- 4012x4980の縦写真で拡大率が1.241倍になっていたが、期待値は1.5倍
- 他の縦写真解像度では適切な値が得られていた

## 解決策
縦写真の拡大率計算を以下の統一的な計算式に変更：

```python
scale = dng_width / jpeg_width
```

## 検証結果
- 2580 x 6016: `dng_width / 2580 = 2.332倍` ✓
- 4012 x 6016: `dng_width / 4012 = 1.5倍` ✓  
- 4012 x 4980: `dng_width / 4012 = 1.5倍` ✓

## メリット
- 全ての縦写真解像度で統一的に動作
- DNGの実際の解像度を活用
- 固定値を使用しない柔軟な計算
- シンプルで保守しやすい

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)