### PR TITLE
Fix: Issue #22 横写真のDNGファイルの拡大率計算を修正

### DIFF
--- a/DRSorter.py
+++ b/DRSorter.py
@@ -381,10 +381,8 @@ def main():
                             dng_width, dng_height = map(int, dng_res.split('x'))
                             
                             if jpeg_width > jpeg_height:  # 横写真の場合
-                                # JPEGとDNGのアスペクト比を比較してスケールを計算
-                                scale_x = (jpeg_width / dng_width) * (dng_height / jpeg_height)
-                                scale_y = 1.0
-                                scale = max(scale_x, scale_y)
+                                # 縦写真と同じ統一計算式を使用
+                                scale = dng_width / jpeg_width
                             elif jpeg_width < jpeg_height:  # 縦写真の場合
                                 # DNGの幅をJPEGの幅で割る統一計算式
                                 scale = dng_width / jpeg_width


### PR DESCRIPTION
## 概要
- 横写真のDNGファイルの拡大率計算が不正確だった問題を修正
- 縦写真と同じ統一計算式 `dng_width / jpeg_width` を横写真にも適用

## 変更内容
- `DRSorter.py:383-387` の横写真のスケール計算部分を修正
- 複雑で不正確だった計算式 `(jpeg_width / dng_width) * (dng_height / jpeg_height)` を削除
- 縦写真で使用されている統一計算式に変更

## 修正前の問題
- 5348x4012の横写真で約1.125倍のズームが必要なのに、計算が不足していた
- ネイティブ解像度6016x4012に対して正しい拡大率が計算されていなかった

## テスト計画
- [ ] 横写真（5348x4012等）でDNGファイルの拡大率が正しく計算されることを確認
- [ ] 縦写真の処理に影響がないことを確認
- [ ] 正方形写真の処理に影響がないことを確認

## 関連Issue
Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)